### PR TITLE
Replace deprecated function and color role

### DIFF
--- a/Code Snapshots/05 Interactivity & Theming/20 Using Theme in Widgets/lib/widgets/expenses_list/expenses_list.dart
+++ b/Code Snapshots/05 Interactivity & Theming/20 Using Theme in Widgets/lib/widgets/expenses_list/expenses_list.dart
@@ -20,7 +20,7 @@ class ExpensesList extends StatelessWidget {
       itemBuilder: (ctx, index) => Dismissible(
         key: ValueKey(expenses[index]),
         background: Container(
-          color: Theme.of(context).colorScheme.error.withOpacity(0.75),
+          color: Theme.of(context).colorScheme.error.withValues(alpha: 0.75),
           margin: EdgeInsets.symmetric(
             horizontal: Theme.of(context).cardTheme.margin!.horizontal,
           ),

--- a/Code Snapshots/05 Interactivity & Theming/21 Dark Mode/lib/widgets/expenses_list/expenses_list.dart
+++ b/Code Snapshots/05 Interactivity & Theming/21 Dark Mode/lib/widgets/expenses_list/expenses_list.dart
@@ -20,7 +20,7 @@ class ExpensesList extends StatelessWidget {
       itemBuilder: (ctx, index) => Dismissible(
         key: ValueKey(expenses[index]),
         background: Container(
-          color: Theme.of(context).colorScheme.error.withOpacity(0.75),
+          color: Theme.of(context).colorScheme.error.withValues(alpha: 0.75),
           margin: EdgeInsets.symmetric(
             horizontal: Theme.of(context).cardTheme.margin!.horizontal,
           ),

--- a/Code Snapshots/05 Interactivity & Theming/22 Adding Alternative Constructor Functions/lib/widgets/expenses_list/expenses_list.dart
+++ b/Code Snapshots/05 Interactivity & Theming/22 Adding Alternative Constructor Functions/lib/widgets/expenses_list/expenses_list.dart
@@ -20,7 +20,7 @@ class ExpensesList extends StatelessWidget {
       itemBuilder: (ctx, index) => Dismissible(
         key: ValueKey(expenses[index]),
         background: Container(
-          color: Theme.of(context).colorScheme.error.withOpacity(0.75),
+          color: Theme.of(context).colorScheme.error.withValues(alpha: 0.75),
           margin: EdgeInsets.symmetric(
             horizontal: Theme.of(context).cardTheme.margin!.horizontal,
           ),

--- a/Code Snapshots/05 Interactivity & Theming/23 Added Chart Widgets/lib/widgets/chart/chart.dart
+++ b/Code Snapshots/05 Interactivity & Theming/23 Added Chart Widgets/lib/widgets/chart/chart.dart
@@ -45,8 +45,8 @@ class Chart extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         gradient: LinearGradient(
           colors: [
-            Theme.of(context).colorScheme.primary.withOpacity(0.3),
-            Theme.of(context).colorScheme.primary.withOpacity(0.0)
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.0)
           ],
           begin: Alignment.bottomCenter,
           end: Alignment.topCenter,
@@ -81,7 +81,7 @@ class Chart extends StatelessWidget {
                             : Theme.of(context)
                                 .colorScheme
                                 .primary
-                                .withOpacity(0.7),
+                                .withValues(alpha: 0.7),
                       ),
                     ),
                   ),

--- a/Code Snapshots/05 Interactivity & Theming/23 Added Chart Widgets/lib/widgets/chart/chart_bar.dart
+++ b/Code Snapshots/05 Interactivity & Theming/23 Added Chart Widgets/lib/widgets/chart/chart_bar.dart
@@ -24,7 +24,7 @@ class ChartBar extends StatelessWidget {
                   const BorderRadius.vertical(top: Radius.circular(8)),
               color: isDarkMode
                   ? Theme.of(context).colorScheme.secondary
-                  : Theme.of(context).colorScheme.primary.withOpacity(0.65),
+                  : Theme.of(context).colorScheme.primary.withValues(alpha: 0.65),
             ),
           ),
         ),

--- a/Code Snapshots/05 Interactivity & Theming/23 Added Chart Widgets/lib/widgets/expenses_list/expenses_list.dart
+++ b/Code Snapshots/05 Interactivity & Theming/23 Added Chart Widgets/lib/widgets/expenses_list/expenses_list.dart
@@ -20,7 +20,7 @@ class ExpensesList extends StatelessWidget {
       itemBuilder: (ctx, index) => Dismissible(
         key: ValueKey(expenses[index]),
         background: Container(
-          color: Theme.of(context).colorScheme.error.withOpacity(0.75),
+          color: Theme.of(context).colorScheme.error.withValues(alpha: 0.75),
           margin: EdgeInsets.symmetric(
             horizontal: Theme.of(context).cardTheme.margin!.horizontal,
           ),

--- a/Code Snapshots/05 Interactivity & Theming/24 Finished/lib/widgets/chart/chart.dart
+++ b/Code Snapshots/05 Interactivity & Theming/24 Finished/lib/widgets/chart/chart.dart
@@ -45,8 +45,8 @@ class Chart extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         gradient: LinearGradient(
           colors: [
-            Theme.of(context).colorScheme.primary.withOpacity(0.3),
-            Theme.of(context).colorScheme.primary.withOpacity(0.0)
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.0)
           ],
           begin: Alignment.bottomCenter,
           end: Alignment.topCenter,
@@ -81,7 +81,7 @@ class Chart extends StatelessWidget {
                             : Theme.of(context)
                                 .colorScheme
                                 .primary
-                                .withOpacity(0.7),
+                                .withValues(alpha: 0.7),
                       ),
                     ),
                   ),

--- a/Code Snapshots/05 Interactivity & Theming/24 Finished/lib/widgets/chart/chart_bar.dart
+++ b/Code Snapshots/05 Interactivity & Theming/24 Finished/lib/widgets/chart/chart_bar.dart
@@ -24,7 +24,7 @@ class ChartBar extends StatelessWidget {
                   const BorderRadius.vertical(top: Radius.circular(8)),
               color: isDarkMode
                   ? Theme.of(context).colorScheme.secondary
-                  : Theme.of(context).colorScheme.primary.withOpacity(0.65),
+                  : Theme.of(context).colorScheme.primary.withValues(alpha: 0.65),
             ),
           ),
         ),

--- a/Code Snapshots/05 Interactivity & Theming/24 Finished/lib/widgets/expenses_list/expenses_list.dart
+++ b/Code Snapshots/05 Interactivity & Theming/24 Finished/lib/widgets/expenses_list/expenses_list.dart
@@ -20,7 +20,7 @@ class ExpensesList extends StatelessWidget {
       itemBuilder: (ctx, index) => Dismissible(
         key: ValueKey(expenses[index]),
         background: Container(
-          color: Theme.of(context).colorScheme.error.withOpacity(0.75),
+          color: Theme.of(context).colorScheme.error.withValues(alpha: 0.75),
           margin: EdgeInsets.symmetric(
             horizontal: Theme.of(context).cardTheme.margin!.horizontal,
           ),

--- a/Code Snapshots/06 Responsive & Adaptive/01 Starting Setup/lib/widgets/chart/chart.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/01 Starting Setup/lib/widgets/chart/chart.dart
@@ -45,8 +45,8 @@ class Chart extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         gradient: LinearGradient(
           colors: [
-            Theme.of(context).colorScheme.primary.withOpacity(0.3),
-            Theme.of(context).colorScheme.primary.withOpacity(0.0)
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.0)
           ],
           begin: Alignment.bottomCenter,
           end: Alignment.topCenter,
@@ -81,7 +81,7 @@ class Chart extends StatelessWidget {
                             : Theme.of(context)
                                 .colorScheme
                                 .primary
-                                .withOpacity(0.7),
+                                .withValues(alpha: 0.7),
                       ),
                     ),
                   ),

--- a/Code Snapshots/06 Responsive & Adaptive/01 Starting Setup/lib/widgets/chart/chart_bar.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/01 Starting Setup/lib/widgets/chart/chart_bar.dart
@@ -24,7 +24,7 @@ class ChartBar extends StatelessWidget {
                   const BorderRadius.vertical(top: Radius.circular(8)),
               color: isDarkMode
                   ? Theme.of(context).colorScheme.secondary
-                  : Theme.of(context).colorScheme.primary.withOpacity(0.65),
+                  : Theme.of(context).colorScheme.primary.withValues(alpha: 0.65),
             ),
           ),
         ),

--- a/Code Snapshots/06 Responsive & Adaptive/01 Starting Setup/lib/widgets/expenses_list/expenses_list.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/01 Starting Setup/lib/widgets/expenses_list/expenses_list.dart
@@ -20,7 +20,7 @@ class ExpensesList extends StatelessWidget {
       itemBuilder: (ctx, index) => Dismissible(
         key: ValueKey(expenses[index]),
         background: Container(
-          color: Theme.of(context).colorScheme.error.withOpacity(0.75),
+          color: Theme.of(context).colorScheme.error.withValues(alpha: 0.75),
           margin: EdgeInsets.symmetric(
             horizontal: Theme.of(context).cardTheme.margin!.horizontal,
           ),

--- a/Code Snapshots/06 Responsive & Adaptive/02 Locking Device Orientation/lib/widgets/chart/chart.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/02 Locking Device Orientation/lib/widgets/chart/chart.dart
@@ -45,8 +45,8 @@ class Chart extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         gradient: LinearGradient(
           colors: [
-            Theme.of(context).colorScheme.primary.withOpacity(0.3),
-            Theme.of(context).colorScheme.primary.withOpacity(0.0)
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.0)
           ],
           begin: Alignment.bottomCenter,
           end: Alignment.topCenter,
@@ -81,7 +81,7 @@ class Chart extends StatelessWidget {
                             : Theme.of(context)
                                 .colorScheme
                                 .primary
-                                .withOpacity(0.7),
+                                .withValues(alpha: 0.7),
                       ),
                     ),
                   ),

--- a/Code Snapshots/06 Responsive & Adaptive/02 Locking Device Orientation/lib/widgets/chart/chart_bar.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/02 Locking Device Orientation/lib/widgets/chart/chart_bar.dart
@@ -24,7 +24,7 @@ class ChartBar extends StatelessWidget {
                   const BorderRadius.vertical(top: Radius.circular(8)),
               color: isDarkMode
                   ? Theme.of(context).colorScheme.secondary
-                  : Theme.of(context).colorScheme.primary.withOpacity(0.65),
+                  : Theme.of(context).colorScheme.primary.withValues(alpha: 0.65),
             ),
           ),
         ),

--- a/Code Snapshots/06 Responsive & Adaptive/02 Locking Device Orientation/lib/widgets/expenses_list/expenses_list.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/02 Locking Device Orientation/lib/widgets/expenses_list/expenses_list.dart
@@ -20,7 +20,7 @@ class ExpensesList extends StatelessWidget {
       itemBuilder: (ctx, index) => Dismissible(
         key: ValueKey(expenses[index]),
         background: Container(
-          color: Theme.of(context).colorScheme.error.withOpacity(0.75),
+          color: Theme.of(context).colorScheme.error.withValues(alpha: 0.75),
           margin: EdgeInsets.symmetric(
             horizontal: Theme.of(context).cardTheme.margin!.horizontal,
           ),

--- a/Code Snapshots/06 Responsive & Adaptive/03 Updating the UI Based on Available Space/lib/widgets/chart/chart.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/03 Updating the UI Based on Available Space/lib/widgets/chart/chart.dart
@@ -45,8 +45,8 @@ class Chart extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         gradient: LinearGradient(
           colors: [
-            Theme.of(context).colorScheme.primary.withOpacity(0.3),
-            Theme.of(context).colorScheme.primary.withOpacity(0.0)
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.0)
           ],
           begin: Alignment.bottomCenter,
           end: Alignment.topCenter,
@@ -81,7 +81,7 @@ class Chart extends StatelessWidget {
                             : Theme.of(context)
                                 .colorScheme
                                 .primary
-                                .withOpacity(0.7),
+                                .withValues(alpha: 0.7),
                       ),
                     ),
                   ),

--- a/Code Snapshots/06 Responsive & Adaptive/03 Updating the UI Based on Available Space/lib/widgets/chart/chart_bar.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/03 Updating the UI Based on Available Space/lib/widgets/chart/chart_bar.dart
@@ -24,7 +24,7 @@ class ChartBar extends StatelessWidget {
                   const BorderRadius.vertical(top: Radius.circular(8)),
               color: isDarkMode
                   ? Theme.of(context).colorScheme.secondary
-                  : Theme.of(context).colorScheme.primary.withOpacity(0.65),
+                  : Theme.of(context).colorScheme.primary.withValues(alpha: 0.65),
             ),
           ),
         ),

--- a/Code Snapshots/06 Responsive & Adaptive/03 Updating the UI Based on Available Space/lib/widgets/expenses_list/expenses_list.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/03 Updating the UI Based on Available Space/lib/widgets/expenses_list/expenses_list.dart
@@ -20,7 +20,7 @@ class ExpensesList extends StatelessWidget {
       itemBuilder: (ctx, index) => Dismissible(
         key: ValueKey(expenses[index]),
         background: Container(
-          color: Theme.of(context).colorScheme.error.withOpacity(0.75),
+          color: Theme.of(context).colorScheme.error.withValues(alpha: 0.75),
           margin: EdgeInsets.symmetric(
             horizontal: Theme.of(context).cardTheme.margin!.horizontal,
           ),

--- a/Code Snapshots/06 Responsive & Adaptive/04 Handling Screen Overlays/lib/widgets/chart/chart.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/04 Handling Screen Overlays/lib/widgets/chart/chart.dart
@@ -45,8 +45,8 @@ class Chart extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         gradient: LinearGradient(
           colors: [
-            Theme.of(context).colorScheme.primary.withOpacity(0.3),
-            Theme.of(context).colorScheme.primary.withOpacity(0.0)
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.0)
           ],
           begin: Alignment.bottomCenter,
           end: Alignment.topCenter,
@@ -81,7 +81,7 @@ class Chart extends StatelessWidget {
                             : Theme.of(context)
                                 .colorScheme
                                 .primary
-                                .withOpacity(0.7),
+                                .withValues(alpha: 0.7),
                       ),
                     ),
                   ),

--- a/Code Snapshots/06 Responsive & Adaptive/04 Handling Screen Overlays/lib/widgets/chart/chart_bar.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/04 Handling Screen Overlays/lib/widgets/chart/chart_bar.dart
@@ -24,7 +24,7 @@ class ChartBar extends StatelessWidget {
                   const BorderRadius.vertical(top: Radius.circular(8)),
               color: isDarkMode
                   ? Theme.of(context).colorScheme.secondary
-                  : Theme.of(context).colorScheme.primary.withOpacity(0.65),
+                  : Theme.of(context).colorScheme.primary.withValues(alpha: 0.65),
             ),
           ),
         ),

--- a/Code Snapshots/06 Responsive & Adaptive/04 Handling Screen Overlays/lib/widgets/expenses_list/expenses_list.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/04 Handling Screen Overlays/lib/widgets/expenses_list/expenses_list.dart
@@ -20,7 +20,7 @@ class ExpensesList extends StatelessWidget {
       itemBuilder: (ctx, index) => Dismissible(
         key: ValueKey(expenses[index]),
         background: Container(
-          color: Theme.of(context).colorScheme.error.withOpacity(0.75),
+          color: Theme.of(context).colorScheme.error.withValues(alpha: 0.75),
           margin: EdgeInsets.symmetric(
             horizontal: Theme.of(context).cardTheme.margin!.horizontal,
           ),

--- a/Code Snapshots/06 Responsive & Adaptive/05 SafeArea/lib/widgets/chart/chart.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/05 SafeArea/lib/widgets/chart/chart.dart
@@ -45,8 +45,8 @@ class Chart extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         gradient: LinearGradient(
           colors: [
-            Theme.of(context).colorScheme.primary.withOpacity(0.3),
-            Theme.of(context).colorScheme.primary.withOpacity(0.0)
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.0)
           ],
           begin: Alignment.bottomCenter,
           end: Alignment.topCenter,
@@ -81,7 +81,7 @@ class Chart extends StatelessWidget {
                             : Theme.of(context)
                                 .colorScheme
                                 .primary
-                                .withOpacity(0.7),
+                                .withValues(alpha: 0.7),
                       ),
                     ),
                   ),

--- a/Code Snapshots/06 Responsive & Adaptive/05 SafeArea/lib/widgets/chart/chart_bar.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/05 SafeArea/lib/widgets/chart/chart_bar.dart
@@ -24,7 +24,7 @@ class ChartBar extends StatelessWidget {
                   const BorderRadius.vertical(top: Radius.circular(8)),
               color: isDarkMode
                   ? Theme.of(context).colorScheme.secondary
-                  : Theme.of(context).colorScheme.primary.withOpacity(0.65),
+                  : Theme.of(context).colorScheme.primary.withValues(alpha: 0.65),
             ),
           ),
         ),

--- a/Code Snapshots/06 Responsive & Adaptive/05 SafeArea/lib/widgets/expenses_list/expenses_list.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/05 SafeArea/lib/widgets/expenses_list/expenses_list.dart
@@ -20,7 +20,7 @@ class ExpensesList extends StatelessWidget {
       itemBuilder: (ctx, index) => Dismissible(
         key: ValueKey(expenses[index]),
         background: Container(
-          color: Theme.of(context).colorScheme.error.withOpacity(0.75),
+          color: Theme.of(context).colorScheme.error.withValues(alpha: 0.75),
           margin: EdgeInsets.symmetric(
             horizontal: Theme.of(context).cardTheme.margin!.horizontal,
           ),

--- a/Code Snapshots/06 Responsive & Adaptive/06 LayoutBuilder/lib/widgets/chart/chart.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/06 LayoutBuilder/lib/widgets/chart/chart.dart
@@ -45,8 +45,8 @@ class Chart extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         gradient: LinearGradient(
           colors: [
-            Theme.of(context).colorScheme.primary.withOpacity(0.3),
-            Theme.of(context).colorScheme.primary.withOpacity(0.0)
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.0)
           ],
           begin: Alignment.bottomCenter,
           end: Alignment.topCenter,
@@ -81,7 +81,7 @@ class Chart extends StatelessWidget {
                             : Theme.of(context)
                                 .colorScheme
                                 .primary
-                                .withOpacity(0.7),
+                                .withValues(alpha: 0.7),
                       ),
                     ),
                   ),

--- a/Code Snapshots/06 Responsive & Adaptive/06 LayoutBuilder/lib/widgets/chart/chart_bar.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/06 LayoutBuilder/lib/widgets/chart/chart_bar.dart
@@ -24,7 +24,7 @@ class ChartBar extends StatelessWidget {
                   const BorderRadius.vertical(top: Radius.circular(8)),
               color: isDarkMode
                   ? Theme.of(context).colorScheme.secondary
-                  : Theme.of(context).colorScheme.primary.withOpacity(0.65),
+                  : Theme.of(context).colorScheme.primary.withValues(alpha: 0.65),
             ),
           ),
         ),

--- a/Code Snapshots/06 Responsive & Adaptive/06 LayoutBuilder/lib/widgets/expenses_list/expenses_list.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/06 LayoutBuilder/lib/widgets/expenses_list/expenses_list.dart
@@ -20,7 +20,7 @@ class ExpensesList extends StatelessWidget {
       itemBuilder: (ctx, index) => Dismissible(
         key: ValueKey(expenses[index]),
         background: Container(
-          color: Theme.of(context).colorScheme.error.withOpacity(0.75),
+          color: Theme.of(context).colorScheme.error.withValues(alpha: 0.75),
           margin: EdgeInsets.symmetric(
             horizontal: Theme.of(context).cardTheme.margin!.horizontal,
           ),

--- a/Code Snapshots/06 Responsive & Adaptive/07 Adaptive Apps & Widgets/lib/widgets/chart/chart.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/07 Adaptive Apps & Widgets/lib/widgets/chart/chart.dart
@@ -45,8 +45,8 @@ class Chart extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         gradient: LinearGradient(
           colors: [
-            Theme.of(context).colorScheme.primary.withOpacity(0.3),
-            Theme.of(context).colorScheme.primary.withOpacity(0.0)
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.0)
           ],
           begin: Alignment.bottomCenter,
           end: Alignment.topCenter,
@@ -81,7 +81,7 @@ class Chart extends StatelessWidget {
                             : Theme.of(context)
                                 .colorScheme
                                 .primary
-                                .withOpacity(0.7),
+                                .withValues(alpha: 0.7),
                       ),
                     ),
                   ),

--- a/Code Snapshots/06 Responsive & Adaptive/07 Adaptive Apps & Widgets/lib/widgets/chart/chart_bar.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/07 Adaptive Apps & Widgets/lib/widgets/chart/chart_bar.dart
@@ -24,7 +24,7 @@ class ChartBar extends StatelessWidget {
                   const BorderRadius.vertical(top: Radius.circular(8)),
               color: isDarkMode
                   ? Theme.of(context).colorScheme.secondary
-                  : Theme.of(context).colorScheme.primary.withOpacity(0.65),
+                  : Theme.of(context).colorScheme.primary.withValues(alpha: 0.65),
             ),
           ),
         ),

--- a/Code Snapshots/06 Responsive & Adaptive/07 Adaptive Apps & Widgets/lib/widgets/expenses_list/expenses_list.dart
+++ b/Code Snapshots/06 Responsive & Adaptive/07 Adaptive Apps & Widgets/lib/widgets/expenses_list/expenses_list.dart
@@ -20,7 +20,7 @@ class ExpensesList extends StatelessWidget {
       itemBuilder: (ctx, index) => Dismissible(
         key: ValueKey(expenses[index]),
         background: Container(
-          color: Theme.of(context).colorScheme.error.withOpacity(0.75),
+          color: Theme.of(context).colorScheme.error.withValues(alpha: 0.75),
           margin: EdgeInsets.symmetric(
             horizontal: Theme.of(context).cardTheme.margin!.horizontal,
           ),

--- a/Code Snapshots/08 Navigation/03 Displaying Category Items/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/08 Navigation/03 Displaying Category Items/lib/widgets/category_grid_item.dart
@@ -17,8 +17,8 @@ class CategoryGridItem extends StatelessWidget {
       decoration: BoxDecoration(
           gradient: LinearGradient(
         colors: [
-          category.color.withOpacity(0.55),
-          category.color.withOpacity(0.9),
+          category.color.withValues(alpha: 0.55),
+          category.color.withValues(alpha: 0.9),
         ],
         begin: Alignment.topLeft,
         end: Alignment.bottomRight,
@@ -26,7 +26,7 @@ class CategoryGridItem extends StatelessWidget {
       child: Text(
         category.title,
         style: Theme.of(context).textTheme.titleLarge!.copyWith(
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
       ),
     );

--- a/Code Snapshots/08 Navigation/04 InkWell/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/08 Navigation/04 InkWell/lib/widgets/category_grid_item.dart
@@ -22,8 +22,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -31,7 +31,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/08 Navigation/05 Loading Meals Data/lib/screens/meals.dart
+++ b/Code Snapshots/08 Navigation/05 Loading Meals Data/lib/screens/meals.dart
@@ -21,14 +21,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/08 Navigation/05 Loading Meals Data/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/08 Navigation/05 Loading Meals Data/lib/widgets/category_grid_item.dart
@@ -22,8 +22,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -31,7 +31,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/08 Navigation/06 Adding Cross-Screen Navigation/lib/screens/meals.dart
+++ b/Code Snapshots/08 Navigation/06 Adding Cross-Screen Navigation/lib/screens/meals.dart
@@ -21,14 +21,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/08 Navigation/06 Adding Cross-Screen Navigation/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/08 Navigation/06 Adding Cross-Screen Navigation/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/08 Navigation/07 Passing Data to Routes/lib/screens/meals.dart
+++ b/Code Snapshots/08 Navigation/07 Passing Data to Routes/lib/screens/meals.dart
@@ -21,14 +21,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/08 Navigation/07 Passing Data to Routes/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/08 Navigation/07 Passing Data to Routes/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/08 Navigation/08 Added MealItems/lib/screens/meals.dart
+++ b/Code Snapshots/08 Navigation/08 Added MealItems/lib/screens/meals.dart
@@ -22,14 +22,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/08 Navigation/08 Added MealItems/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/08 Navigation/08 Added MealItems/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/08 Navigation/09 Navigating to MealDetailScreen/lib/screens/meals.dart
+++ b/Code Snapshots/08 Navigation/09 Navigating to MealDetailScreen/lib/screens/meals.dart
@@ -33,14 +33,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/08 Navigation/09 Navigating to MealDetailScreen/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/08 Navigation/09 Navigating to MealDetailScreen/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/08 Navigation/10 Updating the MealDetailsScreen/lib/screens/meal_details.dart
+++ b/Code Snapshots/08 Navigation/10 Updating the MealDetailsScreen/lib/screens/meal_details.dart
@@ -38,7 +38,7 @@ class MealDetailsScreen extends StatelessWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -60,7 +60,7 @@ class MealDetailsScreen extends StatelessWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/08 Navigation/10 Updating the MealDetailsScreen/lib/screens/meals.dart
+++ b/Code Snapshots/08 Navigation/10 Updating the MealDetailsScreen/lib/screens/meals.dart
@@ -33,14 +33,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/08 Navigation/10 Updating the MealDetailsScreen/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/08 Navigation/10 Updating the MealDetailsScreen/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/08 Navigation/11 Tab Navigation/lib/screens/meal_details.dart
+++ b/Code Snapshots/08 Navigation/11 Tab Navigation/lib/screens/meal_details.dart
@@ -38,7 +38,7 @@ class MealDetailsScreen extends StatelessWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -60,7 +60,7 @@ class MealDetailsScreen extends StatelessWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/08 Navigation/11 Tab Navigation/lib/screens/meals.dart
+++ b/Code Snapshots/08 Navigation/11 Tab Navigation/lib/screens/meals.dart
@@ -33,14 +33,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/08 Navigation/11 Tab Navigation/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/08 Navigation/11 Tab Navigation/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/08 Navigation/12 Passing Functions Through Widget Layers/lib/screens/meal_details.dart
+++ b/Code Snapshots/08 Navigation/12 Passing Functions Through Widget Layers/lib/screens/meal_details.dart
@@ -45,7 +45,7 @@ class MealDetailsScreen extends StatelessWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -67,7 +67,7 @@ class MealDetailsScreen extends StatelessWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/08 Navigation/12 Passing Functions Through Widget Layers/lib/screens/meals.dart
+++ b/Code Snapshots/08 Navigation/12 Passing Functions Through Widget Layers/lib/screens/meals.dart
@@ -36,14 +36,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/08 Navigation/12 Passing Functions Through Widget Layers/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/08 Navigation/12 Passing Functions Through Widget Layers/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/08 Navigation/13 Managing App-wide State/lib/screens/meal_details.dart
+++ b/Code Snapshots/08 Navigation/13 Managing App-wide State/lib/screens/meal_details.dart
@@ -45,7 +45,7 @@ class MealDetailsScreen extends StatelessWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -67,7 +67,7 @@ class MealDetailsScreen extends StatelessWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/08 Navigation/13 Managing App-wide State/lib/screens/meals.dart
+++ b/Code Snapshots/08 Navigation/13 Managing App-wide State/lib/screens/meals.dart
@@ -36,14 +36,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/08 Navigation/13 Managing App-wide State/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/08 Navigation/13 Managing App-wide State/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/08 Navigation/14 Drawer/lib/screens/meal_details.dart
+++ b/Code Snapshots/08 Navigation/14 Drawer/lib/screens/meal_details.dart
@@ -45,7 +45,7 @@ class MealDetailsScreen extends StatelessWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -67,7 +67,7 @@ class MealDetailsScreen extends StatelessWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/08 Navigation/14 Drawer/lib/screens/meals.dart
+++ b/Code Snapshots/08 Navigation/14 Drawer/lib/screens/meals.dart
@@ -36,14 +36,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/08 Navigation/14 Drawer/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/08 Navigation/14 Drawer/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/08 Navigation/14 Drawer/lib/widgets/main_drawer.dart
+++ b/Code Snapshots/08 Navigation/14 Drawer/lib/widgets/main_drawer.dart
@@ -17,7 +17,7 @@ class MainDrawer extends StatelessWidget {
                   Theme.of(context)
                       .colorScheme
                       .primaryContainer
-                      .withOpacity(0.8),
+                      .withValues(alpha: 0.8),
                 ],
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
@@ -44,12 +44,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.restaurant,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Meals',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),
@@ -59,12 +59,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.settings,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Filters',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),

--- a/Code Snapshots/08 Navigation/15 Replacing Screens/lib/screens/filters.dart
+++ b/Code Snapshots/08 Navigation/15 Replacing Screens/lib/screens/filters.dart
@@ -44,13 +44,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
           title: Text(
             'Gluten-free',
             style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           subtitle: Text(
             'Only include gluten-free meals.',
             style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           activeColor: Theme.of(context).colorScheme.tertiary,

--- a/Code Snapshots/08 Navigation/15 Replacing Screens/lib/screens/meal_details.dart
+++ b/Code Snapshots/08 Navigation/15 Replacing Screens/lib/screens/meal_details.dart
@@ -45,7 +45,7 @@ class MealDetailsScreen extends StatelessWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -67,7 +67,7 @@ class MealDetailsScreen extends StatelessWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/08 Navigation/15 Replacing Screens/lib/screens/meals.dart
+++ b/Code Snapshots/08 Navigation/15 Replacing Screens/lib/screens/meals.dart
@@ -36,14 +36,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/08 Navigation/15 Replacing Screens/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/08 Navigation/15 Replacing Screens/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/08 Navigation/15 Replacing Screens/lib/widgets/main_drawer.dart
+++ b/Code Snapshots/08 Navigation/15 Replacing Screens/lib/widgets/main_drawer.dart
@@ -19,7 +19,7 @@ class MainDrawer extends StatelessWidget {
                   Theme.of(context)
                       .colorScheme
                       .primaryContainer
-                      .withOpacity(0.8),
+                      .withValues(alpha: 0.8),
                 ],
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
@@ -46,12 +46,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.restaurant,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Meals',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),
@@ -63,12 +63,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.settings,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Filters',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),

--- a/Code Snapshots/08 Navigation/16 Filters Screen/lib/screens/filters.dart
+++ b/Code Snapshots/08 Navigation/16 Filters Screen/lib/screens/filters.dart
@@ -48,13 +48,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
             title: Text(
               'Gluten-free',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include gluten-free meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -70,13 +70,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
             title: Text(
               'Lactose-free',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include lactose-free meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -92,13 +92,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
             title: Text(
               'Vegetarian',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include vegetarian meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -114,13 +114,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
             title: Text(
               'Vegan',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include vegan meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,

--- a/Code Snapshots/08 Navigation/16 Filters Screen/lib/screens/meal_details.dart
+++ b/Code Snapshots/08 Navigation/16 Filters Screen/lib/screens/meal_details.dart
@@ -45,7 +45,7 @@ class MealDetailsScreen extends StatelessWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -67,7 +67,7 @@ class MealDetailsScreen extends StatelessWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/08 Navigation/16 Filters Screen/lib/screens/meals.dart
+++ b/Code Snapshots/08 Navigation/16 Filters Screen/lib/screens/meals.dart
@@ -36,14 +36,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/08 Navigation/16 Filters Screen/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/08 Navigation/16 Filters Screen/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/08 Navigation/16 Filters Screen/lib/widgets/main_drawer.dart
+++ b/Code Snapshots/08 Navigation/16 Filters Screen/lib/widgets/main_drawer.dart
@@ -19,7 +19,7 @@ class MainDrawer extends StatelessWidget {
                   Theme.of(context)
                       .colorScheme
                       .primaryContainer
-                      .withOpacity(0.8),
+                      .withValues(alpha: 0.8),
                 ],
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
@@ -46,12 +46,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.restaurant,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Meals',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),
@@ -63,12 +63,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.settings,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Filters',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),

--- a/Code Snapshots/08 Navigation/17 Finished/lib/screens/filters.dart
+++ b/Code Snapshots/08 Navigation/17 Finished/lib/screens/filters.dart
@@ -76,13 +76,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               title: Text(
                 'Gluten-free',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include gluten-free meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,
@@ -98,13 +98,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               title: Text(
                 'Lactose-free',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include lactose-free meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,
@@ -120,13 +120,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               title: Text(
                 'Vegetarian',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include vegetarian meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,
@@ -142,13 +142,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               title: Text(
                 'Vegan',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include vegan meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,

--- a/Code Snapshots/08 Navigation/17 Finished/lib/screens/meal_details.dart
+++ b/Code Snapshots/08 Navigation/17 Finished/lib/screens/meal_details.dart
@@ -45,7 +45,7 @@ class MealDetailsScreen extends StatelessWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -67,7 +67,7 @@ class MealDetailsScreen extends StatelessWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/08 Navigation/17 Finished/lib/screens/meals.dart
+++ b/Code Snapshots/08 Navigation/17 Finished/lib/screens/meals.dart
@@ -36,14 +36,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/08 Navigation/17 Finished/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/08 Navigation/17 Finished/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/08 Navigation/17 Finished/lib/widgets/main_drawer.dart
+++ b/Code Snapshots/08 Navigation/17 Finished/lib/widgets/main_drawer.dart
@@ -19,7 +19,7 @@ class MainDrawer extends StatelessWidget {
                   Theme.of(context)
                       .colorScheme
                       .primaryContainer
-                      .withOpacity(0.8),
+                      .withValues(alpha: 0.8),
                 ],
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
@@ -46,12 +46,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.restaurant,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Meals',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),
@@ -63,12 +63,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.settings,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Filters',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),

--- a/Code Snapshots/09 State Management/01 Starting Setup/lib/screens/filters.dart
+++ b/Code Snapshots/09 State Management/01 Starting Setup/lib/screens/filters.dart
@@ -76,13 +76,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               title: Text(
                 'Gluten-free',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include gluten-free meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,
@@ -98,13 +98,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               title: Text(
                 'Lactose-free',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include lactose-free meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,
@@ -120,13 +120,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               title: Text(
                 'Vegetarian',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include vegetarian meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,
@@ -142,13 +142,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               title: Text(
                 'Vegan',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include vegan meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,

--- a/Code Snapshots/09 State Management/01 Starting Setup/lib/screens/meal_details.dart
+++ b/Code Snapshots/09 State Management/01 Starting Setup/lib/screens/meal_details.dart
@@ -45,7 +45,7 @@ class MealDetailsScreen extends StatelessWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -67,7 +67,7 @@ class MealDetailsScreen extends StatelessWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/09 State Management/01 Starting Setup/lib/screens/meals.dart
+++ b/Code Snapshots/09 State Management/01 Starting Setup/lib/screens/meals.dart
@@ -36,14 +36,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/09 State Management/01 Starting Setup/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/09 State Management/01 Starting Setup/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/09 State Management/01 Starting Setup/lib/widgets/main_drawer.dart
+++ b/Code Snapshots/09 State Management/01 Starting Setup/lib/widgets/main_drawer.dart
@@ -19,7 +19,7 @@ class MainDrawer extends StatelessWidget {
                   Theme.of(context)
                       .colorScheme
                       .primaryContainer
-                      .withOpacity(0.8),
+                      .withValues(alpha: 0.8),
                 ],
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
@@ -46,12 +46,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.restaurant,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Meals',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),
@@ -63,12 +63,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.settings,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Filters',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),

--- a/Code Snapshots/09 State Management/02 Using a Provider/lib/screens/filters.dart
+++ b/Code Snapshots/09 State Management/02 Using a Provider/lib/screens/filters.dart
@@ -76,13 +76,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               title: Text(
                 'Gluten-free',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include gluten-free meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,
@@ -98,13 +98,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               title: Text(
                 'Lactose-free',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include lactose-free meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,
@@ -120,13 +120,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               title: Text(
                 'Vegetarian',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include vegetarian meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,
@@ -142,13 +142,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               title: Text(
                 'Vegan',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include vegan meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,

--- a/Code Snapshots/09 State Management/02 Using a Provider/lib/screens/meal_details.dart
+++ b/Code Snapshots/09 State Management/02 Using a Provider/lib/screens/meal_details.dart
@@ -45,7 +45,7 @@ class MealDetailsScreen extends StatelessWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -67,7 +67,7 @@ class MealDetailsScreen extends StatelessWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/09 State Management/02 Using a Provider/lib/screens/meals.dart
+++ b/Code Snapshots/09 State Management/02 Using a Provider/lib/screens/meals.dart
@@ -36,14 +36,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/09 State Management/02 Using a Provider/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/09 State Management/02 Using a Provider/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/09 State Management/02 Using a Provider/lib/widgets/main_drawer.dart
+++ b/Code Snapshots/09 State Management/02 Using a Provider/lib/widgets/main_drawer.dart
@@ -19,7 +19,7 @@ class MainDrawer extends StatelessWidget {
                   Theme.of(context)
                       .colorScheme
                       .primaryContainer
-                      .withOpacity(0.8),
+                      .withValues(alpha: 0.8),
                 ],
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
@@ -46,12 +46,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.restaurant,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Meals',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),
@@ -63,12 +63,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.settings,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Filters',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),

--- a/Code Snapshots/09 State Management/03 Triggering a Notifier Method/lib/screens/filters.dart
+++ b/Code Snapshots/09 State Management/03 Triggering a Notifier Method/lib/screens/filters.dart
@@ -76,13 +76,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               title: Text(
                 'Gluten-free',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include gluten-free meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,
@@ -98,13 +98,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               title: Text(
                 'Lactose-free',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include lactose-free meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,
@@ -120,13 +120,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               title: Text(
                 'Vegetarian',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include vegetarian meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,
@@ -142,13 +142,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               title: Text(
                 'Vegan',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include vegan meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,

--- a/Code Snapshots/09 State Management/03 Triggering a Notifier Method/lib/screens/meal_details.dart
+++ b/Code Snapshots/09 State Management/03 Triggering a Notifier Method/lib/screens/meal_details.dart
@@ -54,7 +54,7 @@ class MealDetailsScreen extends ConsumerWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -76,7 +76,7 @@ class MealDetailsScreen extends ConsumerWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/09 State Management/03 Triggering a Notifier Method/lib/screens/meals.dart
+++ b/Code Snapshots/09 State Management/03 Triggering a Notifier Method/lib/screens/meals.dart
@@ -33,14 +33,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/09 State Management/03 Triggering a Notifier Method/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/09 State Management/03 Triggering a Notifier Method/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/09 State Management/03 Triggering a Notifier Method/lib/widgets/main_drawer.dart
+++ b/Code Snapshots/09 State Management/03 Triggering a Notifier Method/lib/widgets/main_drawer.dart
@@ -19,7 +19,7 @@ class MainDrawer extends StatelessWidget {
                   Theme.of(context)
                       .colorScheme
                       .primaryContainer
-                      .withOpacity(0.8),
+                      .withValues(alpha: 0.8),
                 ],
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
@@ -46,12 +46,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.restaurant,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Meals',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),
@@ -63,12 +63,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.settings,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Filters',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),

--- a/Code Snapshots/09 State Management/04 Combining Local & Provider State/lib/screens/filters.dart
+++ b/Code Snapshots/09 State Management/04 Combining Local & Provider State/lib/screens/filters.dart
@@ -71,13 +71,13 @@ class _FiltersScreenState extends ConsumerState<FiltersScreen> {
               title: Text(
                 'Gluten-free',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include gluten-free meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,
@@ -93,13 +93,13 @@ class _FiltersScreenState extends ConsumerState<FiltersScreen> {
               title: Text(
                 'Lactose-free',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include lactose-free meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,
@@ -115,13 +115,13 @@ class _FiltersScreenState extends ConsumerState<FiltersScreen> {
               title: Text(
                 'Vegetarian',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include vegetarian meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,
@@ -137,13 +137,13 @@ class _FiltersScreenState extends ConsumerState<FiltersScreen> {
               title: Text(
                 'Vegan',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include vegan meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,

--- a/Code Snapshots/09 State Management/04 Combining Local & Provider State/lib/screens/meal_details.dart
+++ b/Code Snapshots/09 State Management/04 Combining Local & Provider State/lib/screens/meal_details.dart
@@ -54,7 +54,7 @@ class MealDetailsScreen extends ConsumerWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -76,7 +76,7 @@ class MealDetailsScreen extends ConsumerWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/09 State Management/04 Combining Local & Provider State/lib/screens/meals.dart
+++ b/Code Snapshots/09 State Management/04 Combining Local & Provider State/lib/screens/meals.dart
@@ -33,14 +33,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/09 State Management/04 Combining Local & Provider State/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/09 State Management/04 Combining Local & Provider State/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/09 State Management/04 Combining Local & Provider State/lib/widgets/main_drawer.dart
+++ b/Code Snapshots/09 State Management/04 Combining Local & Provider State/lib/widgets/main_drawer.dart
@@ -19,7 +19,7 @@ class MainDrawer extends StatelessWidget {
                   Theme.of(context)
                       .colorScheme
                       .primaryContainer
-                      .withOpacity(0.8),
+                      .withValues(alpha: 0.8),
                 ],
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
@@ -46,12 +46,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.restaurant,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Meals',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),
@@ -63,12 +63,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.settings,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Filters',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),

--- a/Code Snapshots/09 State Management/05 Outsourcing State to a Provider/lib/screens/filters.dart
+++ b/Code Snapshots/09 State Management/05 Outsourcing State to a Provider/lib/screens/filters.dart
@@ -28,13 +28,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Gluten-free',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include gluten-free meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -50,13 +50,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Lactose-free',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include lactose-free meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -72,13 +72,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Vegetarian',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include vegetarian meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -94,13 +94,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Vegan',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include vegan meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,

--- a/Code Snapshots/09 State Management/05 Outsourcing State to a Provider/lib/screens/meal_details.dart
+++ b/Code Snapshots/09 State Management/05 Outsourcing State to a Provider/lib/screens/meal_details.dart
@@ -54,7 +54,7 @@ class MealDetailsScreen extends ConsumerWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -76,7 +76,7 @@ class MealDetailsScreen extends ConsumerWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/09 State Management/05 Outsourcing State to a Provider/lib/screens/meals.dart
+++ b/Code Snapshots/09 State Management/05 Outsourcing State to a Provider/lib/screens/meals.dart
@@ -33,14 +33,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/09 State Management/05 Outsourcing State to a Provider/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/09 State Management/05 Outsourcing State to a Provider/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/09 State Management/05 Outsourcing State to a Provider/lib/widgets/main_drawer.dart
+++ b/Code Snapshots/09 State Management/05 Outsourcing State to a Provider/lib/widgets/main_drawer.dart
@@ -19,7 +19,7 @@ class MainDrawer extends StatelessWidget {
                   Theme.of(context)
                       .colorScheme
                       .primaryContainer
-                      .withOpacity(0.8),
+                      .withValues(alpha: 0.8),
                 ],
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
@@ -46,12 +46,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.restaurant,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Meals',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),
@@ -63,12 +63,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.settings,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Filters',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),

--- a/Code Snapshots/09 State Management/06 Connecting Multiple Providers/lib/screens/filters.dart
+++ b/Code Snapshots/09 State Management/06 Connecting Multiple Providers/lib/screens/filters.dart
@@ -28,13 +28,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Gluten-free',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include gluten-free meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -50,13 +50,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Lactose-free',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include lactose-free meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -72,13 +72,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Vegetarian',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include vegetarian meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -94,13 +94,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Vegan',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include vegan meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,

--- a/Code Snapshots/09 State Management/06 Connecting Multiple Providers/lib/screens/meal_details.dart
+++ b/Code Snapshots/09 State Management/06 Connecting Multiple Providers/lib/screens/meal_details.dart
@@ -54,7 +54,7 @@ class MealDetailsScreen extends ConsumerWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -76,7 +76,7 @@ class MealDetailsScreen extends ConsumerWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/09 State Management/06 Connecting Multiple Providers/lib/screens/meals.dart
+++ b/Code Snapshots/09 State Management/06 Connecting Multiple Providers/lib/screens/meals.dart
@@ -33,14 +33,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/09 State Management/06 Connecting Multiple Providers/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/09 State Management/06 Connecting Multiple Providers/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/09 State Management/06 Connecting Multiple Providers/lib/widgets/main_drawer.dart
+++ b/Code Snapshots/09 State Management/06 Connecting Multiple Providers/lib/widgets/main_drawer.dart
@@ -19,7 +19,7 @@ class MainDrawer extends StatelessWidget {
                   Theme.of(context)
                       .colorScheme
                       .primaryContainer
-                      .withOpacity(0.8),
+                      .withValues(alpha: 0.8),
                 ],
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
@@ -46,12 +46,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.restaurant,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Meals',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),
@@ -63,12 +63,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.settings,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Filters',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),

--- a/Code Snapshots/09 State Management/07 Finished/lib/screens/filters.dart
+++ b/Code Snapshots/09 State Management/07 Finished/lib/screens/filters.dart
@@ -28,13 +28,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Gluten-free',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include gluten-free meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -50,13 +50,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Lactose-free',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include lactose-free meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -72,13 +72,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Vegetarian',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include vegetarian meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -94,13 +94,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Vegan',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include vegan meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,

--- a/Code Snapshots/09 State Management/07 Finished/lib/screens/meal_details.dart
+++ b/Code Snapshots/09 State Management/07 Finished/lib/screens/meal_details.dart
@@ -58,7 +58,7 @@ class MealDetailsScreen extends ConsumerWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -80,7 +80,7 @@ class MealDetailsScreen extends ConsumerWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/09 State Management/07 Finished/lib/screens/meals.dart
+++ b/Code Snapshots/09 State Management/07 Finished/lib/screens/meals.dart
@@ -33,14 +33,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/09 State Management/07 Finished/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/09 State Management/07 Finished/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/09 State Management/07 Finished/lib/widgets/main_drawer.dart
+++ b/Code Snapshots/09 State Management/07 Finished/lib/widgets/main_drawer.dart
@@ -19,7 +19,7 @@ class MainDrawer extends StatelessWidget {
                   Theme.of(context)
                       .colorScheme
                       .primaryContainer
-                      .withOpacity(0.8),
+                      .withValues(alpha: 0.8),
                 ],
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
@@ -46,12 +46,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.restaurant,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Meals',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),
@@ -63,12 +63,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.settings,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Filters',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),

--- a/Code Snapshots/10 Animations/01 Starting Setup/lib/screens/filters.dart
+++ b/Code Snapshots/10 Animations/01 Starting Setup/lib/screens/filters.dart
@@ -28,13 +28,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Gluten-free',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include gluten-free meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -50,13 +50,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Lactose-free',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include lactose-free meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -72,13 +72,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Vegetarian',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include vegetarian meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -94,13 +94,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Vegan',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include vegan meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,

--- a/Code Snapshots/10 Animations/01 Starting Setup/lib/screens/meal_details.dart
+++ b/Code Snapshots/10 Animations/01 Starting Setup/lib/screens/meal_details.dart
@@ -58,7 +58,7 @@ class MealDetailsScreen extends ConsumerWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -80,7 +80,7 @@ class MealDetailsScreen extends ConsumerWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/10 Animations/01 Starting Setup/lib/screens/meals.dart
+++ b/Code Snapshots/10 Animations/01 Starting Setup/lib/screens/meals.dart
@@ -33,14 +33,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/10 Animations/01 Starting Setup/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/10 Animations/01 Starting Setup/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/10 Animations/01 Starting Setup/lib/widgets/main_drawer.dart
+++ b/Code Snapshots/10 Animations/01 Starting Setup/lib/widgets/main_drawer.dart
@@ -19,7 +19,7 @@ class MainDrawer extends StatelessWidget {
                   Theme.of(context)
                       .colorScheme
                       .primaryContainer
-                      .withOpacity(0.8),
+                      .withValues(alpha: 0.8),
                 ],
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
@@ -46,12 +46,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.restaurant,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Meals',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),
@@ -63,12 +63,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.settings,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Filters',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),

--- a/Code Snapshots/10 Animations/02 First explicit animation/lib/screens/filters.dart
+++ b/Code Snapshots/10 Animations/02 First explicit animation/lib/screens/filters.dart
@@ -28,13 +28,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Gluten-free',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include gluten-free meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -50,13 +50,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Lactose-free',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include lactose-free meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -72,13 +72,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Vegetarian',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include vegetarian meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -94,13 +94,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Vegan',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include vegan meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,

--- a/Code Snapshots/10 Animations/02 First explicit animation/lib/screens/meal_details.dart
+++ b/Code Snapshots/10 Animations/02 First explicit animation/lib/screens/meal_details.dart
@@ -58,7 +58,7 @@ class MealDetailsScreen extends ConsumerWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -80,7 +80,7 @@ class MealDetailsScreen extends ConsumerWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/10 Animations/02 First explicit animation/lib/screens/meals.dart
+++ b/Code Snapshots/10 Animations/02 First explicit animation/lib/screens/meals.dart
@@ -33,14 +33,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/10 Animations/02 First explicit animation/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/10 Animations/02 First explicit animation/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/10 Animations/02 First explicit animation/lib/widgets/main_drawer.dart
+++ b/Code Snapshots/10 Animations/02 First explicit animation/lib/widgets/main_drawer.dart
@@ -19,7 +19,7 @@ class MainDrawer extends StatelessWidget {
                   Theme.of(context)
                       .colorScheme
                       .primaryContainer
-                      .withOpacity(0.8),
+                      .withValues(alpha: 0.8),
                 ],
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
@@ -46,12 +46,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.restaurant,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Meals',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),
@@ -63,12 +63,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.settings,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Filters',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),

--- a/Code Snapshots/10 Animations/03 finished explicit/lib/screens/filters.dart
+++ b/Code Snapshots/10 Animations/03 finished explicit/lib/screens/filters.dart
@@ -28,13 +28,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Gluten-free',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include gluten-free meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -50,13 +50,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Lactose-free',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include lactose-free meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -72,13 +72,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Vegetarian',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include vegetarian meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -94,13 +94,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Vegan',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include vegan meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,

--- a/Code Snapshots/10 Animations/03 finished explicit/lib/screens/meal_details.dart
+++ b/Code Snapshots/10 Animations/03 finished explicit/lib/screens/meal_details.dart
@@ -58,7 +58,7 @@ class MealDetailsScreen extends ConsumerWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -80,7 +80,7 @@ class MealDetailsScreen extends ConsumerWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/10 Animations/03 finished explicit/lib/screens/meals.dart
+++ b/Code Snapshots/10 Animations/03 finished explicit/lib/screens/meals.dart
@@ -33,14 +33,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/10 Animations/03 finished explicit/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/10 Animations/03 finished explicit/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/10 Animations/03 finished explicit/lib/widgets/main_drawer.dart
+++ b/Code Snapshots/10 Animations/03 finished explicit/lib/widgets/main_drawer.dart
@@ -19,7 +19,7 @@ class MainDrawer extends StatelessWidget {
                   Theme.of(context)
                       .colorScheme
                       .primaryContainer
-                      .withOpacity(0.8),
+                      .withValues(alpha: 0.8),
                 ],
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
@@ -46,12 +46,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.restaurant,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Meals',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),
@@ -63,12 +63,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.settings,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Filters',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),

--- a/Code Snapshots/10 Animations/04 implicit/lib/screens/filters.dart
+++ b/Code Snapshots/10 Animations/04 implicit/lib/screens/filters.dart
@@ -28,13 +28,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Gluten-free',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include gluten-free meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -50,13 +50,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Lactose-free',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include lactose-free meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -72,13 +72,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Vegetarian',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include vegetarian meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -94,13 +94,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Vegan',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include vegan meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,

--- a/Code Snapshots/10 Animations/04 implicit/lib/screens/meal_details.dart
+++ b/Code Snapshots/10 Animations/04 implicit/lib/screens/meal_details.dart
@@ -70,7 +70,7 @@ class MealDetailsScreen extends ConsumerWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -92,7 +92,7 @@ class MealDetailsScreen extends ConsumerWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/10 Animations/04 implicit/lib/screens/meals.dart
+++ b/Code Snapshots/10 Animations/04 implicit/lib/screens/meals.dart
@@ -33,14 +33,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/10 Animations/04 implicit/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/10 Animations/04 implicit/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/10 Animations/04 implicit/lib/widgets/main_drawer.dart
+++ b/Code Snapshots/10 Animations/04 implicit/lib/widgets/main_drawer.dart
@@ -19,7 +19,7 @@ class MainDrawer extends StatelessWidget {
                   Theme.of(context)
                       .colorScheme
                       .primaryContainer
-                      .withOpacity(0.8),
+                      .withValues(alpha: 0.8),
                 ],
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
@@ -46,12 +46,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.restaurant,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Meals',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),
@@ -63,12 +63,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.settings,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Filters',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),

--- a/Code Snapshots/10 Animations/05 Finished/lib/screens/filters.dart
+++ b/Code Snapshots/10 Animations/05 Finished/lib/screens/filters.dart
@@ -28,13 +28,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Gluten-free',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include gluten-free meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -50,13 +50,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Lactose-free',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include lactose-free meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -72,13 +72,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Vegetarian',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include vegetarian meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -94,13 +94,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Vegan',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include vegan meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,

--- a/Code Snapshots/10 Animations/05 Finished/lib/screens/meal_details.dart
+++ b/Code Snapshots/10 Animations/05 Finished/lib/screens/meal_details.dart
@@ -73,7 +73,7 @@ class MealDetailsScreen extends ConsumerWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -95,7 +95,7 @@ class MealDetailsScreen extends ConsumerWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/10 Animations/05 Finished/lib/screens/meals.dart
+++ b/Code Snapshots/10 Animations/05 Finished/lib/screens/meals.dart
@@ -33,14 +33,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Code Snapshots/10 Animations/05 Finished/lib/widgets/category_grid_item.dart
+++ b/Code Snapshots/10 Animations/05 Finished/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/10 Animations/05 Finished/lib/widgets/main_drawer.dart
+++ b/Code Snapshots/10 Animations/05 Finished/lib/widgets/main_drawer.dart
@@ -19,7 +19,7 @@ class MainDrawer extends StatelessWidget {
                   Theme.of(context)
                       .colorScheme
                       .primaryContainer
-                      .withOpacity(0.8),
+                      .withValues(alpha: 0.8),
                 ],
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
@@ -46,12 +46,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.restaurant,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Meals',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),
@@ -63,12 +63,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.settings,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Filters',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),

--- a/Code Snapshots/13 Native Device Features/02 Adding a Places Screen/lib/widgets/places_list.dart
+++ b/Code Snapshots/13 Native Device Features/02 Adding a Places Screen/lib/widgets/places_list.dart
@@ -14,7 +14,7 @@ class PlacesList extends StatelessWidget {
         child: Text(
           'No places added yet',
           style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       );
@@ -26,7 +26,7 @@ class PlacesList extends StatelessWidget {
         title: Text(
           places[index].title,
           style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/13 Native Device Features/03 AddPlace Screen/lib/screens/add_place.dart
+++ b/Code Snapshots/13 Native Device Features/03 AddPlace Screen/lib/screens/add_place.dart
@@ -32,7 +32,7 @@ class _AddPlaceScreenState extends State<AddPlaceScreen> {
               decoration: const InputDecoration(labelText: 'Title'),
               controller: _titleController,
               style: TextStyle(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
             const SizedBox(height: 16),

--- a/Code Snapshots/13 Native Device Features/03 AddPlace Screen/lib/widgets/places_list.dart
+++ b/Code Snapshots/13 Native Device Features/03 AddPlace Screen/lib/widgets/places_list.dart
@@ -14,7 +14,7 @@ class PlacesList extends StatelessWidget {
         child: Text(
           'No places added yet',
           style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       );
@@ -26,7 +26,7 @@ class PlacesList extends StatelessWidget {
         title: Text(
           places[index].title,
           style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/13 Native Device Features/04 Added riverpod/lib/screens/add_place.dart
+++ b/Code Snapshots/13 Native Device Features/04 Added riverpod/lib/screens/add_place.dart
@@ -47,7 +47,7 @@ class _AddPlaceScreenState extends ConsumerState<AddPlaceScreen> {
               decoration: const InputDecoration(labelText: 'Title'),
               controller: _titleController,
               style: TextStyle(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
             const SizedBox(height: 16),

--- a/Code Snapshots/13 Native Device Features/04 Added riverpod/lib/widgets/places_list.dart
+++ b/Code Snapshots/13 Native Device Features/04 Added riverpod/lib/widgets/places_list.dart
@@ -14,7 +14,7 @@ class PlacesList extends StatelessWidget {
         child: Text(
           'No places added yet',
           style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       );
@@ -26,7 +26,7 @@ class PlacesList extends StatelessWidget {
         title: Text(
           places[index].title,
           style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/13 Native Device Features/05 PlaceDetail screen/lib/screens/add_place.dart
+++ b/Code Snapshots/13 Native Device Features/05 PlaceDetail screen/lib/screens/add_place.dart
@@ -47,7 +47,7 @@ class _AddPlaceScreenState extends ConsumerState<AddPlaceScreen> {
               decoration: const InputDecoration(labelText: 'Title'),
               controller: _titleController,
               style: TextStyle(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
             const SizedBox(height: 16),

--- a/Code Snapshots/13 Native Device Features/05 PlaceDetail screen/lib/screens/place_detail.dart
+++ b/Code Snapshots/13 Native Device Features/05 PlaceDetail screen/lib/screens/place_detail.dart
@@ -17,7 +17,7 @@ class PlaceDetailScreen extends StatelessWidget {
         child: Text(
           place.title,
           style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/13 Native Device Features/05 PlaceDetail screen/lib/widgets/places_list.dart
+++ b/Code Snapshots/13 Native Device Features/05 PlaceDetail screen/lib/widgets/places_list.dart
@@ -15,7 +15,7 @@ class PlacesList extends StatelessWidget {
         child: Text(
           'No places added yet',
           style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       );
@@ -27,7 +27,7 @@ class PlacesList extends StatelessWidget {
         title: Text(
           places[index].title,
           style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
         onTap: () {

--- a/Code Snapshots/13 Native Device Features/06 Using the Device Camera/lib/screens/add_place.dart
+++ b/Code Snapshots/13 Native Device Features/06 Using the Device Camera/lib/screens/add_place.dart
@@ -48,7 +48,7 @@ class _AddPlaceScreenState extends ConsumerState<AddPlaceScreen> {
               decoration: const InputDecoration(labelText: 'Title'),
               controller: _titleController,
               style: TextStyle(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
             const SizedBox(height: 10),

--- a/Code Snapshots/13 Native Device Features/06 Using the Device Camera/lib/screens/place_detail.dart
+++ b/Code Snapshots/13 Native Device Features/06 Using the Device Camera/lib/screens/place_detail.dart
@@ -17,7 +17,7 @@ class PlaceDetailScreen extends StatelessWidget {
         child: Text(
           place.title,
           style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Code Snapshots/13 Native Device Features/06 Using the Device Camera/lib/widgets/image_input.dart
+++ b/Code Snapshots/13 Native Device Features/06 Using the Device Camera/lib/widgets/image_input.dart
@@ -53,7 +53,7 @@ class _ImageInputState extends State<ImageInput> {
       decoration: BoxDecoration(
         border: Border.all(
           width: 1,
-          color: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
         ),
       ),
       height: 250,

--- a/Code Snapshots/13 Native Device Features/06 Using the Device Camera/lib/widgets/places_list.dart
+++ b/Code Snapshots/13 Native Device Features/06 Using the Device Camera/lib/widgets/places_list.dart
@@ -15,7 +15,7 @@ class PlacesList extends StatelessWidget {
         child: Text(
           'No places added yet',
           style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       );
@@ -27,7 +27,7 @@ class PlacesList extends StatelessWidget {
         title: Text(
           places[index].title,
           style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
         onTap: () {

--- a/Code Snapshots/13 Native Device Features/07 Previewing the Picked Image/lib/screens/add_place.dart
+++ b/Code Snapshots/13 Native Device Features/07 Previewing the Picked Image/lib/screens/add_place.dart
@@ -53,7 +53,7 @@ class _AddPlaceScreenState extends ConsumerState<AddPlaceScreen> {
               decoration: const InputDecoration(labelText: 'Title'),
               controller: _titleController,
               style: TextStyle(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
             const SizedBox(height: 10),

--- a/Code Snapshots/13 Native Device Features/07 Previewing the Picked Image/lib/widgets/image_input.dart
+++ b/Code Snapshots/13 Native Device Features/07 Previewing the Picked Image/lib/widgets/image_input.dart
@@ -57,7 +57,7 @@ class _ImageInputState extends State<ImageInput> {
       decoration: BoxDecoration(
         border: Border.all(
           width: 1,
-          color: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
         ),
       ),
       height: 250,

--- a/Code Snapshots/13 Native Device Features/07 Previewing the Picked Image/lib/widgets/places_list.dart
+++ b/Code Snapshots/13 Native Device Features/07 Previewing the Picked Image/lib/widgets/places_list.dart
@@ -15,7 +15,7 @@ class PlacesList extends StatelessWidget {
         child: Text(
           'No places added yet',
           style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       );
@@ -31,7 +31,7 @@ class PlacesList extends StatelessWidget {
         title: Text(
           places[index].title,
           style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
         onTap: () {

--- a/Code Snapshots/13 Native Device Features/08 Adding the Location Package/lib/screens/add_place.dart
+++ b/Code Snapshots/13 Native Device Features/08 Adding the Location Package/lib/screens/add_place.dart
@@ -54,7 +54,7 @@ class _AddPlaceScreenState extends ConsumerState<AddPlaceScreen> {
               decoration: const InputDecoration(labelText: 'Title'),
               controller: _titleController,
               style: TextStyle(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
             const SizedBox(height: 10),

--- a/Code Snapshots/13 Native Device Features/08 Adding the Location Package/lib/widgets/image_input.dart
+++ b/Code Snapshots/13 Native Device Features/08 Adding the Location Package/lib/widgets/image_input.dart
@@ -57,7 +57,7 @@ class _ImageInputState extends State<ImageInput> {
       decoration: BoxDecoration(
         border: Border.all(
           width: 1,
-          color: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
         ),
       ),
       height: 250,

--- a/Code Snapshots/13 Native Device Features/08 Adding the Location Package/lib/widgets/location_input.dart
+++ b/Code Snapshots/13 Native Device Features/08 Adding the Location Package/lib/widgets/location_input.dart
@@ -21,14 +21,14 @@ class _LocationInputState extends State<LocationInput> {
           decoration: BoxDecoration(
             border: Border.all(
               width: 1,
-              color: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+              color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
             ),
           ),
           child: Text(
             'No location chosen',
             textAlign: TextAlign.center,
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ),

--- a/Code Snapshots/13 Native Device Features/08 Adding the Location Package/lib/widgets/places_list.dart
+++ b/Code Snapshots/13 Native Device Features/08 Adding the Location Package/lib/widgets/places_list.dart
@@ -15,7 +15,7 @@ class PlacesList extends StatelessWidget {
         child: Text(
           'No places added yet',
           style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       );
@@ -31,7 +31,7 @@ class PlacesList extends StatelessWidget {
         title: Text(
           places[index].title,
           style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
         onTap: () {

--- a/Code Snapshots/13 Native Device Features/09 Get Current Location/lib/screens/add_place.dart
+++ b/Code Snapshots/13 Native Device Features/09 Get Current Location/lib/screens/add_place.dart
@@ -54,7 +54,7 @@ class _AddPlaceScreenState extends ConsumerState<AddPlaceScreen> {
               decoration: const InputDecoration(labelText: 'Title'),
               controller: _titleController,
               style: TextStyle(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
             const SizedBox(height: 10),

--- a/Code Snapshots/13 Native Device Features/09 Get Current Location/lib/widgets/image_input.dart
+++ b/Code Snapshots/13 Native Device Features/09 Get Current Location/lib/widgets/image_input.dart
@@ -57,7 +57,7 @@ class _ImageInputState extends State<ImageInput> {
       decoration: BoxDecoration(
         border: Border.all(
           width: 1,
-          color: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
         ),
       ),
       height: 250,

--- a/Code Snapshots/13 Native Device Features/09 Get Current Location/lib/widgets/location_input.dart
+++ b/Code Snapshots/13 Native Device Features/09 Get Current Location/lib/widgets/location_input.dart
@@ -57,7 +57,7 @@ class _LocationInputState extends State<LocationInput> {
       'No location chosen',
       textAlign: TextAlign.center,
       style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-            color: Theme.of(context).colorScheme.onBackground,
+            color: Theme.of(context).colorScheme.onSurface,
           ),
     );
 
@@ -74,7 +74,7 @@ class _LocationInputState extends State<LocationInput> {
           decoration: BoxDecoration(
             border: Border.all(
               width: 1,
-              color: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+              color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
             ),
           ),
           child: previewContent,

--- a/Code Snapshots/13 Native Device Features/09 Get Current Location/lib/widgets/places_list.dart
+++ b/Code Snapshots/13 Native Device Features/09 Get Current Location/lib/widgets/places_list.dart
@@ -15,7 +15,7 @@ class PlacesList extends StatelessWidget {
         child: Text(
           'No places added yet',
           style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       );
@@ -31,7 +31,7 @@ class PlacesList extends StatelessWidget {
         title: Text(
           places[index].title,
           style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
         onTap: () {

--- a/Code Snapshots/13 Native Device Features/10 Displaying a Location Preview/lib/screens/add_place.dart
+++ b/Code Snapshots/13 Native Device Features/10 Displaying a Location Preview/lib/screens/add_place.dart
@@ -54,7 +54,7 @@ class _AddPlaceScreenState extends ConsumerState<AddPlaceScreen> {
               decoration: const InputDecoration(labelText: 'Title'),
               controller: _titleController,
               style: TextStyle(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
             const SizedBox(height: 10),

--- a/Code Snapshots/13 Native Device Features/10 Displaying a Location Preview/lib/widgets/image_input.dart
+++ b/Code Snapshots/13 Native Device Features/10 Displaying a Location Preview/lib/widgets/image_input.dart
@@ -57,7 +57,7 @@ class _ImageInputState extends State<ImageInput> {
       decoration: BoxDecoration(
         border: Border.all(
           width: 1,
-          color: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
         ),
       ),
       height: 250,

--- a/Code Snapshots/13 Native Device Features/10 Displaying a Location Preview/lib/widgets/location_input.dart
+++ b/Code Snapshots/13 Native Device Features/10 Displaying a Location Preview/lib/widgets/location_input.dart
@@ -85,7 +85,7 @@ class _LocationInputState extends State<LocationInput> {
       'No location chosen',
       textAlign: TextAlign.center,
       style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-            color: Theme.of(context).colorScheme.onBackground,
+            color: Theme.of(context).colorScheme.onSurface,
           ),
     );
 
@@ -111,7 +111,7 @@ class _LocationInputState extends State<LocationInput> {
           decoration: BoxDecoration(
             border: Border.all(
               width: 1,
-              color: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+              color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
             ),
           ),
           child: previewContent,

--- a/Code Snapshots/13 Native Device Features/10 Displaying a Location Preview/lib/widgets/places_list.dart
+++ b/Code Snapshots/13 Native Device Features/10 Displaying a Location Preview/lib/widgets/places_list.dart
@@ -15,7 +15,7 @@ class PlacesList extends StatelessWidget {
         child: Text(
           'No places added yet',
           style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       );
@@ -31,7 +31,7 @@ class PlacesList extends StatelessWidget {
         title: Text(
           places[index].title,
           style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
         onTap: () {

--- a/Code Snapshots/13 Native Device Features/11 Outputting the Location Data/lib/screens/add_place.dart
+++ b/Code Snapshots/13 Native Device Features/11 Outputting the Location Data/lib/screens/add_place.dart
@@ -58,7 +58,7 @@ class _AddPlaceScreenState extends ConsumerState<AddPlaceScreen> {
               decoration: const InputDecoration(labelText: 'Title'),
               controller: _titleController,
               style: TextStyle(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
             const SizedBox(height: 10),

--- a/Code Snapshots/13 Native Device Features/11 Outputting the Location Data/lib/screens/place_detail.dart
+++ b/Code Snapshots/13 Native Device Features/11 Outputting the Location Data/lib/screens/place_detail.dart
@@ -57,7 +57,7 @@ class PlaceDetailScreen extends StatelessWidget {
                     place.location.address,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/13 Native Device Features/11 Outputting the Location Data/lib/widgets/image_input.dart
+++ b/Code Snapshots/13 Native Device Features/11 Outputting the Location Data/lib/widgets/image_input.dart
@@ -57,7 +57,7 @@ class _ImageInputState extends State<ImageInput> {
       decoration: BoxDecoration(
         border: Border.all(
           width: 1,
-          color: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
         ),
       ),
       height: 250,

--- a/Code Snapshots/13 Native Device Features/11 Outputting the Location Data/lib/widgets/location_input.dart
+++ b/Code Snapshots/13 Native Device Features/11 Outputting the Location Data/lib/widgets/location_input.dart
@@ -89,7 +89,7 @@ class _LocationInputState extends State<LocationInput> {
       'No location chosen',
       textAlign: TextAlign.center,
       style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-            color: Theme.of(context).colorScheme.onBackground,
+            color: Theme.of(context).colorScheme.onSurface,
           ),
     );
 
@@ -115,7 +115,7 @@ class _LocationInputState extends State<LocationInput> {
           decoration: BoxDecoration(
             border: Border.all(
               width: 1,
-              color: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+              color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
             ),
           ),
           child: previewContent,

--- a/Code Snapshots/13 Native Device Features/11 Outputting the Location Data/lib/widgets/places_list.dart
+++ b/Code Snapshots/13 Native Device Features/11 Outputting the Location Data/lib/widgets/places_list.dart
@@ -15,7 +15,7 @@ class PlacesList extends StatelessWidget {
         child: Text(
           'No places added yet',
           style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       );
@@ -31,13 +31,13 @@ class PlacesList extends StatelessWidget {
         title: Text(
           places[index].title,
           style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
         subtitle: Text(
           places[index].location.address,
           style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
         onTap: () {

--- a/Code Snapshots/13 Native Device Features/12 Adding a Map Screen/lib/screens/add_place.dart
+++ b/Code Snapshots/13 Native Device Features/12 Adding a Map Screen/lib/screens/add_place.dart
@@ -58,7 +58,7 @@ class _AddPlaceScreenState extends ConsumerState<AddPlaceScreen> {
               decoration: const InputDecoration(labelText: 'Title'),
               controller: _titleController,
               style: TextStyle(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
             const SizedBox(height: 10),

--- a/Code Snapshots/13 Native Device Features/12 Adding a Map Screen/lib/screens/place_detail.dart
+++ b/Code Snapshots/13 Native Device Features/12 Adding a Map Screen/lib/screens/place_detail.dart
@@ -70,7 +70,7 @@ class PlaceDetailScreen extends StatelessWidget {
                     place.location.address,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/13 Native Device Features/12 Adding a Map Screen/lib/widgets/image_input.dart
+++ b/Code Snapshots/13 Native Device Features/12 Adding a Map Screen/lib/widgets/image_input.dart
@@ -57,7 +57,7 @@ class _ImageInputState extends State<ImageInput> {
       decoration: BoxDecoration(
         border: Border.all(
           width: 1,
-          color: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
         ),
       ),
       height: 250,

--- a/Code Snapshots/13 Native Device Features/12 Adding a Map Screen/lib/widgets/location_input.dart
+++ b/Code Snapshots/13 Native Device Features/12 Adding a Map Screen/lib/widgets/location_input.dart
@@ -89,7 +89,7 @@ class _LocationInputState extends State<LocationInput> {
       'No location chosen',
       textAlign: TextAlign.center,
       style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-            color: Theme.of(context).colorScheme.onBackground,
+            color: Theme.of(context).colorScheme.onSurface,
           ),
     );
 
@@ -115,7 +115,7 @@ class _LocationInputState extends State<LocationInput> {
           decoration: BoxDecoration(
             border: Border.all(
               width: 1,
-              color: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+              color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
             ),
           ),
           child: previewContent,

--- a/Code Snapshots/13 Native Device Features/12 Adding a Map Screen/lib/widgets/places_list.dart
+++ b/Code Snapshots/13 Native Device Features/12 Adding a Map Screen/lib/widgets/places_list.dart
@@ -15,7 +15,7 @@ class PlacesList extends StatelessWidget {
         child: Text(
           'No places added yet',
           style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       );
@@ -31,13 +31,13 @@ class PlacesList extends StatelessWidget {
         title: Text(
           places[index].title,
           style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
         subtitle: Text(
           places[index].location.address,
           style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
         onTap: () {

--- a/Code Snapshots/13 Native Device Features/13 Using the Map Screen in the Form/lib/screens/add_place.dart
+++ b/Code Snapshots/13 Native Device Features/13 Using the Map Screen in the Form/lib/screens/add_place.dart
@@ -58,7 +58,7 @@ class _AddPlaceScreenState extends ConsumerState<AddPlaceScreen> {
               decoration: const InputDecoration(labelText: 'Title'),
               controller: _titleController,
               style: TextStyle(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
             const SizedBox(height: 10),

--- a/Code Snapshots/13 Native Device Features/13 Using the Map Screen in the Form/lib/screens/place_detail.dart
+++ b/Code Snapshots/13 Native Device Features/13 Using the Map Screen in the Form/lib/screens/place_detail.dart
@@ -70,7 +70,7 @@ class PlaceDetailScreen extends StatelessWidget {
                     place.location.address,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/13 Native Device Features/13 Using the Map Screen in the Form/lib/widgets/image_input.dart
+++ b/Code Snapshots/13 Native Device Features/13 Using the Map Screen in the Form/lib/widgets/image_input.dart
@@ -57,7 +57,7 @@ class _ImageInputState extends State<ImageInput> {
       decoration: BoxDecoration(
         border: Border.all(
           width: 1,
-          color: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
         ),
       ),
       height: 250,

--- a/Code Snapshots/13 Native Device Features/13 Using the Map Screen in the Form/lib/widgets/location_input.dart
+++ b/Code Snapshots/13 Native Device Features/13 Using the Map Screen in the Form/lib/widgets/location_input.dart
@@ -109,7 +109,7 @@ class _LocationInputState extends State<LocationInput> {
       'No location chosen',
       textAlign: TextAlign.center,
       style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-            color: Theme.of(context).colorScheme.onBackground,
+            color: Theme.of(context).colorScheme.onSurface,
           ),
     );
 
@@ -135,7 +135,7 @@ class _LocationInputState extends State<LocationInput> {
           decoration: BoxDecoration(
             border: Border.all(
               width: 1,
-              color: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+              color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
             ),
           ),
           child: previewContent,

--- a/Code Snapshots/13 Native Device Features/13 Using the Map Screen in the Form/lib/widgets/places_list.dart
+++ b/Code Snapshots/13 Native Device Features/13 Using the Map Screen in the Form/lib/widgets/places_list.dart
@@ -15,7 +15,7 @@ class PlacesList extends StatelessWidget {
         child: Text(
           'No places added yet',
           style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       );
@@ -31,13 +31,13 @@ class PlacesList extends StatelessWidget {
         title: Text(
           places[index].title,
           style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
         subtitle: Text(
           places[index].location.address,
           style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
         onTap: () {

--- a/Code Snapshots/13 Native Device Features/14 Storing the Picked Image Locally/lib/screens/add_place.dart
+++ b/Code Snapshots/13 Native Device Features/14 Storing the Picked Image Locally/lib/screens/add_place.dart
@@ -58,7 +58,7 @@ class _AddPlaceScreenState extends ConsumerState<AddPlaceScreen> {
               decoration: const InputDecoration(labelText: 'Title'),
               controller: _titleController,
               style: TextStyle(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
             const SizedBox(height: 10),

--- a/Code Snapshots/13 Native Device Features/14 Storing the Picked Image Locally/lib/screens/place_detail.dart
+++ b/Code Snapshots/13 Native Device Features/14 Storing the Picked Image Locally/lib/screens/place_detail.dart
@@ -70,7 +70,7 @@ class PlaceDetailScreen extends StatelessWidget {
                     place.location.address,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/13 Native Device Features/14 Storing the Picked Image Locally/lib/widgets/image_input.dart
+++ b/Code Snapshots/13 Native Device Features/14 Storing the Picked Image Locally/lib/widgets/image_input.dart
@@ -57,7 +57,7 @@ class _ImageInputState extends State<ImageInput> {
       decoration: BoxDecoration(
         border: Border.all(
           width: 1,
-          color: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
         ),
       ),
       height: 250,

--- a/Code Snapshots/13 Native Device Features/14 Storing the Picked Image Locally/lib/widgets/location_input.dart
+++ b/Code Snapshots/13 Native Device Features/14 Storing the Picked Image Locally/lib/widgets/location_input.dart
@@ -109,7 +109,7 @@ class _LocationInputState extends State<LocationInput> {
       'No location chosen',
       textAlign: TextAlign.center,
       style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-            color: Theme.of(context).colorScheme.onBackground,
+            color: Theme.of(context).colorScheme.onSurface,
           ),
     );
 
@@ -135,7 +135,7 @@ class _LocationInputState extends State<LocationInput> {
           decoration: BoxDecoration(
             border: Border.all(
               width: 1,
-              color: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+              color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
             ),
           ),
           child: previewContent,

--- a/Code Snapshots/13 Native Device Features/14 Storing the Picked Image Locally/lib/widgets/places_list.dart
+++ b/Code Snapshots/13 Native Device Features/14 Storing the Picked Image Locally/lib/widgets/places_list.dart
@@ -15,7 +15,7 @@ class PlacesList extends StatelessWidget {
         child: Text(
           'No places added yet',
           style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       );
@@ -31,13 +31,13 @@ class PlacesList extends StatelessWidget {
         title: Text(
           places[index].title,
           style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
         subtitle: Text(
           places[index].location.address,
           style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
         onTap: () {

--- a/Code Snapshots/13 Native Device Features/15 Finished/lib/screens/add_place.dart
+++ b/Code Snapshots/13 Native Device Features/15 Finished/lib/screens/add_place.dart
@@ -58,7 +58,7 @@ class _AddPlaceScreenState extends ConsumerState<AddPlaceScreen> {
               decoration: const InputDecoration(labelText: 'Title'),
               controller: _titleController,
               style: TextStyle(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
             const SizedBox(height: 10),

--- a/Code Snapshots/13 Native Device Features/15 Finished/lib/screens/place_detail.dart
+++ b/Code Snapshots/13 Native Device Features/15 Finished/lib/screens/place_detail.dart
@@ -70,7 +70,7 @@ class PlaceDetailScreen extends StatelessWidget {
                     place.location.address,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Code Snapshots/13 Native Device Features/15 Finished/lib/widgets/image_input.dart
+++ b/Code Snapshots/13 Native Device Features/15 Finished/lib/widgets/image_input.dart
@@ -57,7 +57,7 @@ class _ImageInputState extends State<ImageInput> {
       decoration: BoxDecoration(
         border: Border.all(
           width: 1,
-          color: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
         ),
       ),
       height: 250,

--- a/Code Snapshots/13 Native Device Features/15 Finished/lib/widgets/location_input.dart
+++ b/Code Snapshots/13 Native Device Features/15 Finished/lib/widgets/location_input.dart
@@ -109,7 +109,7 @@ class _LocationInputState extends State<LocationInput> {
       'No location chosen',
       textAlign: TextAlign.center,
       style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-            color: Theme.of(context).colorScheme.onBackground,
+            color: Theme.of(context).colorScheme.onSurface,
           ),
     );
 
@@ -135,7 +135,7 @@ class _LocationInputState extends State<LocationInput> {
           decoration: BoxDecoration(
             border: Border.all(
               width: 1,
-              color: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+              color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
             ),
           ),
           child: previewContent,

--- a/Code Snapshots/13 Native Device Features/15 Finished/lib/widgets/places_list.dart
+++ b/Code Snapshots/13 Native Device Features/15 Finished/lib/widgets/places_list.dart
@@ -15,7 +15,7 @@ class PlacesList extends StatelessWidget {
         child: Text(
           'No places added yet',
           style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       );
@@ -31,13 +31,13 @@ class PlacesList extends StatelessWidget {
         title: Text(
           places[index].title,
           style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
         subtitle: Text(
           places[index].location.address,
           style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
         onTap: () {

--- a/Lecture Attachments/05 Interactivity & Theming/chart/chart.dart
+++ b/Lecture Attachments/05 Interactivity & Theming/chart/chart.dart
@@ -45,8 +45,8 @@ class Chart extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         gradient: LinearGradient(
           colors: [
-            Theme.of(context).colorScheme.primary.withOpacity(0.3),
-            Theme.of(context).colorScheme.primary.withOpacity(0.0)
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.0)
           ],
           begin: Alignment.bottomCenter,
           end: Alignment.topCenter,
@@ -81,7 +81,7 @@ class Chart extends StatelessWidget {
                             : Theme.of(context)
                                 .colorScheme
                                 .primary
-                                .withOpacity(0.7),
+                                .withValues(alpha: 0.7),
                       ),
                     ),
                   ),

--- a/Lecture Attachments/05 Interactivity & Theming/chart/chart_bar.dart
+++ b/Lecture Attachments/05 Interactivity & Theming/chart/chart_bar.dart
@@ -24,7 +24,7 @@ class ChartBar extends StatelessWidget {
                   const BorderRadius.vertical(top: Radius.circular(8)),
               color: isDarkMode
                   ? Theme.of(context).colorScheme.secondary
-                  : Theme.of(context).colorScheme.primary.withOpacity(0.65),
+                  : Theme.of(context).colorScheme.primary.withValues(alpha: 0.65),
             ),
           ),
         ),

--- a/Lecture Attachments/06 Responsive & Adaptive/01 Starting Setup/lib/widgets/chart/chart.dart
+++ b/Lecture Attachments/06 Responsive & Adaptive/01 Starting Setup/lib/widgets/chart/chart.dart
@@ -45,8 +45,8 @@ class Chart extends StatelessWidget {
         borderRadius: BorderRadius.circular(8),
         gradient: LinearGradient(
           colors: [
-            Theme.of(context).colorScheme.primary.withOpacity(0.3),
-            Theme.of(context).colorScheme.primary.withOpacity(0.0)
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
+            Theme.of(context).colorScheme.primary.withValues(alpha: 0.0)
           ],
           begin: Alignment.bottomCenter,
           end: Alignment.topCenter,
@@ -81,7 +81,7 @@ class Chart extends StatelessWidget {
                             : Theme.of(context)
                                 .colorScheme
                                 .primary
-                                .withOpacity(0.7),
+                                .withValues(alpha: 0.7),
                       ),
                     ),
                   ),

--- a/Lecture Attachments/06 Responsive & Adaptive/01 Starting Setup/lib/widgets/chart/chart_bar.dart
+++ b/Lecture Attachments/06 Responsive & Adaptive/01 Starting Setup/lib/widgets/chart/chart_bar.dart
@@ -24,7 +24,7 @@ class ChartBar extends StatelessWidget {
                   const BorderRadius.vertical(top: Radius.circular(8)),
               color: isDarkMode
                   ? Theme.of(context).colorScheme.secondary
-                  : Theme.of(context).colorScheme.primary.withOpacity(0.65),
+                  : Theme.of(context).colorScheme.primary.withValues(alpha: 0.65),
             ),
           ),
         ),

--- a/Lecture Attachments/06 Responsive & Adaptive/01 Starting Setup/lib/widgets/expenses_list/expenses_list.dart
+++ b/Lecture Attachments/06 Responsive & Adaptive/01 Starting Setup/lib/widgets/expenses_list/expenses_list.dart
@@ -20,7 +20,7 @@ class ExpensesList extends StatelessWidget {
       itemBuilder: (ctx, index) => Dismissible(
         key: ValueKey(expenses[index]),
         background: Container(
-          color: Theme.of(context).colorScheme.error.withOpacity(0.75),
+          color: Theme.of(context).colorScheme.error.withValues(alpha: 0.75),
           margin: EdgeInsets.symmetric(
             horizontal: Theme.of(context).cardTheme.margin!.horizontal,
           ),

--- a/Lecture Attachments/09 State Management/01 Starting Setup/lib/screens/filters.dart
+++ b/Lecture Attachments/09 State Management/01 Starting Setup/lib/screens/filters.dart
@@ -76,13 +76,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               title: Text(
                 'Gluten-free',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include gluten-free meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,
@@ -98,13 +98,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               title: Text(
                 'Lactose-free',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include lactose-free meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,
@@ -120,13 +120,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               title: Text(
                 'Vegetarian',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include vegetarian meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,
@@ -142,13 +142,13 @@ class _FiltersScreenState extends State<FiltersScreen> {
               title: Text(
                 'Vegan',
                 style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               subtitle: Text(
                 'Only include vegan meals.',
                 style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onBackground,
+                      color: Theme.of(context).colorScheme.onSurface,
                     ),
               ),
               activeColor: Theme.of(context).colorScheme.tertiary,

--- a/Lecture Attachments/09 State Management/01 Starting Setup/lib/screens/meal_details.dart
+++ b/Lecture Attachments/09 State Management/01 Starting Setup/lib/screens/meal_details.dart
@@ -45,7 +45,7 @@ class MealDetailsScreen extends StatelessWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -67,7 +67,7 @@ class MealDetailsScreen extends StatelessWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Lecture Attachments/09 State Management/01 Starting Setup/lib/screens/meals.dart
+++ b/Lecture Attachments/09 State Management/01 Starting Setup/lib/screens/meals.dart
@@ -36,14 +36,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Lecture Attachments/09 State Management/01 Starting Setup/lib/widgets/category_grid_item.dart
+++ b/Lecture Attachments/09 State Management/01 Starting Setup/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Lecture Attachments/09 State Management/01 Starting Setup/lib/widgets/main_drawer.dart
+++ b/Lecture Attachments/09 State Management/01 Starting Setup/lib/widgets/main_drawer.dart
@@ -19,7 +19,7 @@ class MainDrawer extends StatelessWidget {
                   Theme.of(context)
                       .colorScheme
                       .primaryContainer
-                      .withOpacity(0.8),
+                      .withValues(alpha: 0.8),
                 ],
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
@@ -46,12 +46,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.restaurant,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Meals',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),
@@ -63,12 +63,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.settings,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Filters',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),

--- a/Lecture Attachments/10 Animations/01 Starting Setup/lib/screens/filters.dart
+++ b/Lecture Attachments/10 Animations/01 Starting Setup/lib/screens/filters.dart
@@ -28,13 +28,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Gluten-free',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include gluten-free meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -50,13 +50,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Lactose-free',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include lactose-free meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -72,13 +72,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Vegetarian',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include vegetarian meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,
@@ -94,13 +94,13 @@ class FiltersScreen extends ConsumerWidget {
             title: Text(
               'Vegan',
               style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             subtitle: Text(
               'Only include vegan meals.',
               style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                   ),
             ),
             activeColor: Theme.of(context).colorScheme.tertiary,

--- a/Lecture Attachments/10 Animations/01 Starting Setup/lib/screens/meal_details.dart
+++ b/Lecture Attachments/10 Animations/01 Starting Setup/lib/screens/meal_details.dart
@@ -58,7 +58,7 @@ class MealDetailsScreen extends ConsumerWidget {
                 Text(
                   ingredient,
                   style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                        color: Theme.of(context).colorScheme.onBackground,
+                        color: Theme.of(context).colorScheme.onSurface,
                       ),
                 ),
               const SizedBox(height: 24),
@@ -80,7 +80,7 @@ class MealDetailsScreen extends ConsumerWidget {
                     step,
                     textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.onBackground,
+                          color: Theme.of(context).colorScheme.onSurface,
                         ),
                   ),
                 ),

--- a/Lecture Attachments/10 Animations/01 Starting Setup/lib/screens/meals.dart
+++ b/Lecture Attachments/10 Animations/01 Starting Setup/lib/screens/meals.dart
@@ -33,14 +33,14 @@ class MealsScreen extends StatelessWidget {
           Text(
             'Uh oh ... nothing here!',
             style: Theme.of(context).textTheme.headlineLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
           const SizedBox(height: 16),
           Text(
             'Try selecting a different category!',
             style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                  color: Theme.of(context).colorScheme.onBackground,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
           ),
         ],

--- a/Lecture Attachments/10 Animations/01 Starting Setup/lib/widgets/category_grid_item.dart
+++ b/Lecture Attachments/10 Animations/01 Starting Setup/lib/widgets/category_grid_item.dart
@@ -24,8 +24,8 @@ class CategoryGridItem extends StatelessWidget {
             borderRadius: BorderRadius.circular(16),
             gradient: LinearGradient(
               colors: [
-                category.color.withOpacity(0.55),
-                category.color.withOpacity(0.9),
+                category.color.withValues(alpha: 0.55),
+                category.color.withValues(alpha: 0.9),
               ],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
@@ -33,7 +33,7 @@ class CategoryGridItem extends StatelessWidget {
         child: Text(
           category.title,
           style: Theme.of(context).textTheme.titleLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Lecture Attachments/10 Animations/01 Starting Setup/lib/widgets/main_drawer.dart
+++ b/Lecture Attachments/10 Animations/01 Starting Setup/lib/widgets/main_drawer.dart
@@ -19,7 +19,7 @@ class MainDrawer extends StatelessWidget {
                   Theme.of(context)
                       .colorScheme
                       .primaryContainer
-                      .withOpacity(0.8),
+                      .withValues(alpha: 0.8),
                 ],
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
@@ -46,12 +46,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.restaurant,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Meals',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),
@@ -63,12 +63,12 @@ class MainDrawer extends StatelessWidget {
             leading: Icon(
               Icons.settings,
               size: 26,
-              color: Theme.of(context).colorScheme.onBackground,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
             title: Text(
               'Filters',
               style: Theme.of(context).textTheme.titleSmall!.copyWith(
-                    color: Theme.of(context).colorScheme.onBackground,
+                    color: Theme.of(context).colorScheme.onSurface,
                     fontSize: 24,
                   ),
             ),

--- a/Lecture Attachments/13 Native Device Features/Finished Challenge/lib/screens/add_place.dart
+++ b/Lecture Attachments/13 Native Device Features/Finished Challenge/lib/screens/add_place.dart
@@ -47,7 +47,7 @@ class _AddPlaceScreenState extends ConsumerState<AddPlaceScreen> {
               decoration: const InputDecoration(labelText: 'Title'),
               controller: _titleController,
               style: TextStyle(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
             const SizedBox(height: 16),

--- a/Lecture Attachments/13 Native Device Features/Finished Challenge/lib/screens/place_detail.dart
+++ b/Lecture Attachments/13 Native Device Features/Finished Challenge/lib/screens/place_detail.dart
@@ -17,7 +17,7 @@ class PlaceDetailScreen extends StatelessWidget {
         child: Text(
           place.title,
           style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       ),

--- a/Lecture Attachments/13 Native Device Features/Finished Challenge/lib/widgets/places_list.dart
+++ b/Lecture Attachments/13 Native Device Features/Finished Challenge/lib/widgets/places_list.dart
@@ -15,7 +15,7 @@ class PlacesList extends StatelessWidget {
         child: Text(
           'No places added yet',
           style: Theme.of(context).textTheme.bodyLarge!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
       );
@@ -27,7 +27,7 @@ class PlacesList extends StatelessWidget {
         title: Text(
           places[index].title,
           style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                color: Theme.of(context).colorScheme.onBackground,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
         ),
         onTap: () {


### PR DESCRIPTION
The function `withOpacity()` and color role `onBackground` have been deprecated. They should be replaced with `withValues(alpha: ...)` and `onSurface` respectively.

See: [https://docs.flutter.dev/release/breaking-changes/new-color-scheme-roles](https://docs.flutter.dev/release/breaking-changes/new-color-scheme-roles) and [https://docs.flutter.dev/release/breaking-changes/wide-gamut-framework](https://docs.flutter.dev/release/breaking-changes/wide-gamut-framework).