### PR TITLE
Fix restartQuiz not resetting previously selected answers

### DIFF
--- a/Code Snapshots/03 Flutter & Dart Basics II/22 More Dart Features/lib/quiz.dart
+++ b/Code Snapshots/03 Flutter & Dart Basics II/22 More Dart Features/lib/quiz.dart
@@ -36,6 +36,7 @@ class _QuizState extends State<Quiz> {
 
   void restartQuiz() {
     setState(() {
+      _selectedAnswers = [];
       _activeScreen = 'questions-screen';
     });
   }

--- a/Code Snapshots/04 Debugging/01 Starting Setup/lib/quiz.dart
+++ b/Code Snapshots/04 Debugging/01 Starting Setup/lib/quiz.dart
@@ -36,6 +36,7 @@ class _QuizState extends State<Quiz> {
 
   void restartQuiz() {
     setState(() {
+      _selectedAnswers = [];
       _activeScreen = 'questions-screen';
     });
   }

--- a/Lecture Attachments/04 Debugging/01 Starting Setup/lib/quiz.dart
+++ b/Lecture Attachments/04 Debugging/01 Starting Setup/lib/quiz.dart
@@ -36,6 +36,7 @@ class _QuizState extends State<Quiz> {
 
   void restartQuiz() {
     setState(() {
+      _selectedAnswers = [];
       _activeScreen = 'questions-screen';
     });
   }


### PR DESCRIPTION
## What
`restartQuiz()` switches back to the questions screen but leaves `_selectedAnswers` filled, so a restarted quiz starts with the previous run's answers already marked. This adds `_selectedAnswers = [];` to the reset in the three affected snapshots.

## Why
Fixes #11. After finishing a quiz and restarting, the results/selection state leaks between runs.

## Verification
Reproduced by reading the snapshot code: every snapshot that introduces `_selectedAnswers` also calls `restartQuiz`, and the three files listed above were the only ones missing the reset (the final Debugging/02 Finished snapshot already has it).